### PR TITLE
Fix Docker build: Buster EOL apt, TS3 vs modern @types, dirty build c…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,9 @@
-node_modules
+# Keep host build artifacts out of the image build context. These are
+# regenerated inside the container (npm install / tsc / sequelize migrate).
+# Patterns are matched against the context root, so use **/ to also catch
+# app/node_modules and app/build (the COPY source is ./app).
+**/node_modules
+**/build
+db.sqlite
+.git
+Dockerfile.local*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM node:14.12.0-buster
 
 ARG SERVER_PORT=3000
 ENV SERVER_PORT=${SERVER_PORT}
-EXPOSE ${SERVER_PORT}:${SERVER_PORT}
+EXPOSE ${SERVER_PORT}
 
-RUN apt update && apt upgrade -y
+# NOTE: no `apt upgrade` here. The node:14.12.0-buster base is EOL, so Debian
+# Buster has moved to archive.debian.org and `apt update` fails. This is a
+# deliberately-vulnerable app anyway -- we do not want to patch the OS packages.
 RUN useradd -m app
 COPY --chown=app ./app /graphql
 COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,6 @@
     "sequelize-cli": "^5.5.1",
     "sqlite": "^3.0.3",
     "sqlite3": "^4.1.1",
-    "typescript": "^3.4.5"
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
…ontext (#1)

The docker-compose build had bit-rotted three ways and no longer builds from a clean checkout:

- node:14.12.0-buster is EOL, so Debian Buster moved to archive.debian.org and `RUN apt update && apt upgrade -y` fails. Dropped the line entirely -- this is a deliberately-vulnerable app, so patching OS packages is counterproductive.

- typescript was pinned to ^3.4.5 but every @types/* floats on ^, so a fresh `npm install` now pulls @types/express-serve-static-core >=4.17.19, which uses template-literal RouteParameters types that require TS 4.1+. `npm run tsc` then dies with TS1005/TS1110/TS1160 parse errors. Bumped typescript to ^4.9.5; the app's own sources compile cleanly and emit build/ as before.

- .dockerignore only excluded `node_modules` at the context root, so a developer's host app/node_modules and app/build got COPYed into the image, shipping wrong-arch native binaries (argon2/sqlite3) and a stale build. Switched to **/node_modules, **/build, db.sqlite, .git so the image is always built from source inside the container.

Also fixed the invalid `EXPOSE ${SERVER_PORT}:${SERVER_PORT}` host-port mapping.

Verified: clean `docker build` runs tsc + sequelize migrate/seed and produces a container that boots ("API started.") and serves GraphQL introspection.